### PR TITLE
Change Disconnect message to the Throwable's message

### DIFF
--- a/src/main/java/org/spacehq/packetlib/tcp/TcpSession.java
+++ b/src/main/java/org/spacehq/packetlib/tcp/TcpSession.java
@@ -352,7 +352,7 @@ public abstract class TcpSession extends SimpleChannelInboundHandler<Packet> imp
         } else if(cause instanceof WriteTimeoutException) {
             message = "Write timed out.";
         } else {
-            message = "Internal network exception.";
+            message = cause.toString();
         }
 
         this.disconnect(message, cause);


### PR DESCRIPTION
`Throwable#toString()` returns a description of the Throwable that includes the name of the class appended to `Throwable#getLocalizedMessage()`, which can be used for debugging purposes.