### PR TITLE
Set Java version to 1.7 in POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,8 +78,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.5.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
There are 1.7 classes being used, so we should specify that Java 1.7 is required.