### PR TITLE
Ported library to Netty 4.1.4, fixed a bug in Server.java and general code cleanup.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>5.0.0.Alpha2</version>
+            <version>4.1.4.Final</version>
         </dependency>
     </dependencies>
 
@@ -76,20 +76,21 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.5.1</version>
+                <version>3.6.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+					<source>1.7</source>
+					<target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.0.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -100,8 +101,9 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>2.10.4</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -114,7 +116,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.4.1</version>
+                <version>2.4.3</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/src/main/java/org/spacehq/packetlib/Server.java
+++ b/src/main/java/org/spacehq/packetlib/Server.java
@@ -242,7 +242,7 @@ public class Server {
      * @return Whether the server is listening.
      */
     public boolean isListening() {
-        return this.listener.isListening();
+        return this.listener != null && this.listener.isListening();
     }
 
     /**

--- a/src/main/java/org/spacehq/packetlib/Session.java
+++ b/src/main/java/org/spacehq/packetlib/Session.java
@@ -5,7 +5,6 @@ import org.spacehq.packetlib.event.session.SessionListener;
 import org.spacehq.packetlib.packet.Packet;
 import org.spacehq.packetlib.packet.PacketProtocol;
 
-import java.net.InetAddress;
 import java.net.SocketAddress;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/org/spacehq/packetlib/tcp/TcpSession.java
+++ b/src/main/java/org/spacehq/packetlib/tcp/TcpSession.java
@@ -22,7 +22,6 @@ import org.spacehq.packetlib.packet.Packet;
 import org.spacehq.packetlib.packet.PacketProtocol;
 
 import java.net.ConnectException;
-import java.net.InetAddress;
 import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -371,7 +370,7 @@ public abstract class TcpSession extends SimpleChannelInboundHandler<Packet> imp
     }
 
     @Override
-    protected void messageReceived(ChannelHandlerContext ctx, Packet packet) throws Exception {
+    protected void channelRead0(ChannelHandlerContext ctx, Packet packet) throws Exception {
         if(!packet.isPriority()) {
             this.packets.add(packet);
         }


### PR DESCRIPTION
Hi

I ported the PacketLib library to Netty 4.1.4 (latest release) because Netty 5 has been discontinued since November 2015 and we previously encountered thread leaks when using it.

I also added my suggested fix for the "bug" in Server.java with isListening() and removed some unused imports. Finally I updated the versions of the Maven plugins in the pom file.