### PR TITLE
Use one thread per client.

### DIFF
--- a/src/main/java/org/spacehq/packetlib/tcp/TcpClientSession.java
+++ b/src/main/java/org/spacehq/packetlib/tcp/TcpClientSession.java
@@ -44,7 +44,7 @@ public class TcpClientSession extends TcpSession {
                 this.group = new OioEventLoopGroup();
                 bootstrap.channelFactory(new ProxyOioChannelFactory(this.proxy));
             } else {
-                this.group = new NioEventLoopGroup();
+                this.group = new NioEventLoopGroup(1);
                 bootstrap.channel(NioSocketChannel.class);
             }
 


### PR DESCRIPTION
Limiting the Client to use only one thread allows for better scalability when you want to launch multiple clients from a single machine.

I'm not sure if in this case it is better to use `NioEventLoop` instead (which is a `SingleThreadEventLoop`) because I have never worked with Netty before.