### PR TITLE
Update PacketProtocol, StreamNetInput, pom to 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jdk.version>1.7</jdk.version>
+        <jdk.version>1.8</jdk.version>
         <argLine></argLine>
     </properties>
 

--- a/src/main/java/com/github/steveice10/packetlib/io/stream/StreamNetInput.java
+++ b/src/main/java/com/github/steveice10/packetlib/io/stream/StreamNetInput.java
@@ -3,23 +3,23 @@ package com.github.steveice10.packetlib.io.stream;
 import com.github.steveice10.packetlib.io.NetInput;
 
 import java.io.EOFException;
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 /**
  * A NetInput implementation using an InputStream as a backend.
  */
-public class StreamNetInput implements NetInput {
-    private InputStream in;
-
+public class StreamNetInput extends FilterInputStream implements NetInput {
     /**
      * Creates a new StreamNetInput instance.
      *
      * @param in InputStream to read from.
      */
     public StreamNetInput(InputStream in) {
-        this.in = in;
+        super(in);
     }
 
     @Override
@@ -34,7 +34,7 @@ public class StreamNetInput implements NetInput {
 
     @Override
     public int readUnsignedByte() throws IOException {
-        int b = this.in.read();
+        int b = this.read();
         if(b < 0) {
             throw new EOFException();
         }
@@ -125,7 +125,7 @@ public class StreamNetInput implements NetInput {
         byte b[] = new byte[length];
         int n = 0;
         while(n < length) {
-            int count = this.in.read(b, n, length - n);
+            int count = this.read(b, n, length - n);
             if(count < 0) {
                 throw new EOFException();
             }
@@ -138,12 +138,12 @@ public class StreamNetInput implements NetInput {
 
     @Override
     public int readBytes(byte[] b) throws IOException {
-        return this.in.read(b);
+        return this.read(b);
     }
 
     @Override
     public int readBytes(byte[] b, int offset, int length) throws IOException {
-        return this.in.read(b, offset, length);
+        return this.read(b, offset, length);
     }
 
     @Override
@@ -249,32 +249,11 @@ public class StreamNetInput implements NetInput {
     public String readString() throws IOException {
         int length = this.readVarInt();
         byte bytes[] = this.readBytes(length);
-        return new String(bytes, "UTF-8");
+        return new String(bytes, StandardCharsets.UTF_8);
     }
 
     @Override
     public UUID readUUID() throws IOException {
         return new UUID(this.readLong(), this.readLong());
-    }
-
-    @Override
-    public int available() throws IOException {
-        return this.in.available();
-    }
-
-    public void mark(int readLimit) {
-        this.in.mark(readLimit);
-    }
-
-    public boolean markSupported() {
-        return this.in.markSupported();
-    }
-
-    public void reset() throws IOException {
-        this.in.reset();
-    }
-
-    public long skip(long n) throws IOException {
-        return this.in.skip(n);
     }
 }

--- a/src/main/java/com/github/steveice10/packetlib/io/stream/StreamNetInput.java
+++ b/src/main/java/com/github/steveice10/packetlib/io/stream/StreamNetInput.java
@@ -270,6 +270,10 @@ public class StreamNetInput implements NetInput {
         return this.in.markSupported();
     }
 
+    public void reset() throws IOException {
+        this.in.reset();
+    }
+
     public long skip(long n) throws IOException {
         return this.in.skip(n);
     }

--- a/src/main/java/com/github/steveice10/packetlib/io/stream/StreamNetInput.java
+++ b/src/main/java/com/github/steveice10/packetlib/io/stream/StreamNetInput.java
@@ -261,4 +261,16 @@ public class StreamNetInput implements NetInput {
     public int available() throws IOException {
         return this.in.available();
     }
+
+    public void mark(int readLimit) {
+        this.in.mark(readLimit);
+    }
+
+    public boolean markSupported() {
+        return this.in.markSupported();
+    }
+
+    public long skip(long n) throws IOException {
+        return this.in.skip(n);
+    }
 }

--- a/src/main/java/com/github/steveice10/packetlib/io/stream/StreamNetOutput.java
+++ b/src/main/java/com/github/steveice10/packetlib/io/stream/StreamNetOutput.java
@@ -2,23 +2,23 @@ package com.github.steveice10.packetlib.io.stream;
 
 import com.github.steveice10.packetlib.io.NetOutput;
 
+import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 /**
  * A NetOutput implementation using an OutputStream as a backend.
  */
-public class StreamNetOutput implements NetOutput {
-    private OutputStream out;
-
+public class StreamNetOutput extends FilterOutputStream implements NetOutput {
     /**
      * Creates a new StreamNetOutput instance.
      *
      * @param out OutputStream to write to.
      */
     public StreamNetOutput(OutputStream out) {
-        this.out = out;
+        super(out);
     }
 
     @Override
@@ -28,7 +28,7 @@ public class StreamNetOutput implements NetOutput {
 
     @Override
     public void writeByte(int b) throws IOException {
-        this.out.write(b);
+        this.write(b);
     }
 
     @Override
@@ -100,7 +100,7 @@ public class StreamNetOutput implements NetOutput {
 
     @Override
     public void writeBytes(byte b[], int length) throws IOException {
-        this.out.write(b, 0, length);
+        this.write(b, 0, length);
     }
 
     @Override
@@ -145,7 +145,7 @@ public class StreamNetOutput implements NetOutput {
             throw new IllegalArgumentException("String cannot be null!");
         }
 
-        byte[] bytes = s.getBytes("UTF-8");
+        byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
         if(bytes.length > 32767) {
             throw new IOException("String too big (was " + s.length() + " bytes encoded, max " + 32767 + ")");
         } else {
@@ -158,10 +158,5 @@ public class StreamNetOutput implements NetOutput {
     public void writeUUID(UUID uuid) throws IOException {
         this.writeLong(uuid.getMostSignificantBits());
         this.writeLong(uuid.getLeastSignificantBits());
-    }
-
-    @Override
-    public void flush() throws IOException {
-        this.out.flush();
     }
 }

--- a/src/main/java/com/github/steveice10/packetlib/packet/PacketProtocol.java
+++ b/src/main/java/com/github/steveice10/packetlib/packet/PacketProtocol.java
@@ -14,10 +14,10 @@ import java.util.Map;
  * All implementations must have a no-params constructor for server protocol creation.
  */
 public abstract class PacketProtocol {
-    private final Map<Integer, Class<? extends Packet>> incoming = new HashMap<Integer, Class<? extends Packet>>();
-    private final Map<Class<? extends Packet>, Integer> outgoing = new HashMap<Class<? extends Packet>, Integer>();
+    private final Map<Integer, Class<? extends Packet>> incoming = new HashMap<>();
+    private final Map<Class<? extends Packet>, Integer> outgoing = new HashMap<>();
 
-    private final Map<Integer, Class<? extends Packet>> outgoingClasses = new HashMap<Integer, Class<? extends Packet>>();
+    private final Map<Integer, Class<? extends Packet>> outgoingClasses = new HashMap<>();
 
     /**
      * Gets the prefix used when locating SRV records for this protocol.
@@ -110,12 +110,12 @@ public abstract class PacketProtocol {
      *
      * @param id Id of the packet to create.
      * @return The created packet.
-     * @throws IllegalArgumentException If the packet ID less than zero or it is not registered.
+     * @throws IllegalArgumentException If the packet ID is not registered.
      * @throws IllegalStateException    If the packet does not have a no-params constructor or cannot be instantiated.
      */
     public final Packet createIncomingPacket(int id) {
-        Class<? extends Packet> packet;
-        if(id < 0 || (packet = this.incoming.get(id)) == null) {
+        Class<? extends Packet> packet = this.incoming.get(id);
+        if (packet == null) {
             throw new IllegalArgumentException("Invalid packet id: " + id);
         }
 
@@ -168,11 +168,11 @@ public abstract class PacketProtocol {
      * Gets the packet class for a packet id.
      * @param id The packet id.
      * @return The registered packet's class
-     * @throws IllegalArgumentException If the packet ID less than zero or it is not registered.
+     * @throws IllegalArgumentException If the packet ID is not registered.
      */
     public final Class<? extends Packet> getOutgoingClass(int id) {
-        Class<? extends Packet> packet;
-        if(id < 0 || (packet = this.outgoingClasses.get(id)) == null) {
+        Class<? extends Packet> packet = this.outgoingClasses.get(id);
+        if(packet == null) {
             throw new IllegalArgumentException("Invalid packet id: " + id);
         }
 


### PR DESCRIPTION
Added reverse mappings for outgoing packets (class->id) and added some missing InputStream methods to StreamNetInput.

Maven was complaining about dnsjava being Java 1.8, so I updated the pom to fix that.

There are a few syntax changes that can be made to bring the code more inline with 1.7/1.8 (e.g. using the Diamond Operator for the Maps in PacketProtocol), but I didn't include them in case the older style was your preference.