### PR TITLE
Creating instances with unsafe, therefore you do not need to put private empty constructors in your packet.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,11 @@
             <version>4.1.45.Final</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations-java5</artifactId>
+            <version>18.0.0</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
However this does not work on android, but there is a fallback option, (if system cannot get Unsafe, the system will switch to normal Reflection)