### PR TITLE
Add local address binding to Client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,11 @@
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>
+      <dependency>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-annotations</artifactId>
+        <version>4.2.0</version>
+      </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/github/steveice10/packetlib/Client.java
+++ b/src/main/java/com/github/steveice10/packetlib/Client.java
@@ -1,6 +1,8 @@
 package com.github.steveice10.packetlib;
 
 import com.github.steveice10.packetlib.packet.PacketProtocol;
+import com.sun.istack.internal.Nullable;
+import java.net.InetSocketAddress;
 
 /**
  * A client that may connect to a server.
@@ -45,21 +47,28 @@ public class Client {
     }
     
     /**
-     * Gets the the local address the client is connecting from.
+     * Gets the the local address the client is connected from/will be binding to.
      *
-     * @return Client's local IP address or null if default.
+     * @return Client's local IP address, or null if default and not connected.
      */
+    @Nullable
     public String getBindAddress() {
-        return this.bindAddress;
+        final Session session = this.getSession();
+        return session.isConnected()
+            ? ((InetSocketAddress) session.getLocalAddress()).getAddress().getHostAddress()
+            : this.bindAddress;
     }
     
     /**
-     * Gets the the local port the client is connecting from.
+     * Gets the the local port the client is connected from/will be binding to.
      *
-     * @return Client's local port or 0 if default.
+     * @return Client's local port, or 0 if default and not connected.
      */
     public int getBindPort() {
-        return this.bindPort;
+        final Session session = this.getSession();
+        return session.isConnected()
+            ? ((InetSocketAddress) session.getLocalAddress()).getPort()
+            : this.bindPort;
     }
     
     /**

--- a/src/main/java/com/github/steveice10/packetlib/Client.java
+++ b/src/main/java/com/github/steveice10/packetlib/Client.java
@@ -23,7 +23,7 @@ public class Client {
     }
     
     public Client(String host, int port, PacketProtocol protocol, SessionFactory factory) {
-        new Client(host, port, null, 0, protocol, factory);
+        this(host, port, null, 0, protocol, factory);
     }
 
     /**

--- a/src/main/java/com/github/steveice10/packetlib/Client.java
+++ b/src/main/java/com/github/steveice10/packetlib/Client.java
@@ -8,14 +8,22 @@ import com.github.steveice10.packetlib.packet.PacketProtocol;
 public class Client {
     private String host;
     private int port;
+    private String bindAddress;
+    private int bindPort;
     private PacketProtocol protocol;
     private Session session;
 
-    public Client(String host, int port, PacketProtocol protocol, SessionFactory factory) {
+    public Client(String host, int port, String bindAddress, int bindPort, PacketProtocol protocol, SessionFactory factory) {
         this.host = host;
         this.port = port;
+        this.bindAddress = bindAddress;
+        this.bindPort = bindPort;
         this.protocol = protocol;
         this.session = factory.createClientSession(this);
+    }
+    
+    public Client(String host, int port, PacketProtocol protocol, SessionFactory factory) {
+        new Client(host, port, null, 0, protocol, factory);
     }
 
     /**
@@ -35,7 +43,25 @@ public class Client {
     public int getPort() {
         return this.port;
     }
-
+    
+    /**
+     * Gets the the local address the client is connecting from.
+     *
+     * @return Client's local IP address or null if default.
+     */
+    public String getBindAddress() {
+        return this.bindAddress;
+    }
+    
+    /**
+     * Gets the the local port the client is connecting from.
+     *
+     * @return Client's local port or 0 if default.
+     */
+    public int getBindPort() {
+        return this.bindPort;
+    }
+    
     /**
      * Gets the packet protocol of the client.
      *

--- a/src/main/java/com/github/steveice10/packetlib/Client.java
+++ b/src/main/java/com/github/steveice10/packetlib/Client.java
@@ -1,7 +1,7 @@
 package com.github.steveice10.packetlib;
 
 import com.github.steveice10.packetlib.packet.PacketProtocol;
-import com.sun.istack.internal.Nullable;
+import javax.annotation.Nullable;
 import java.net.InetSocketAddress;
 
 /**

--- a/src/main/java/com/github/steveice10/packetlib/tcp/TcpClientSession.java
+++ b/src/main/java/com/github/steveice10/packetlib/tcp/TcpClientSession.java
@@ -142,6 +142,7 @@ public class TcpClientSession extends TcpSession {
                     try {
                         InetSocketAddress remoteAddress = resolveAddress();
                         bootstrap.remoteAddress(remoteAddress);
+                        bootstrap.localAddress(client.getBindAddress(), client.getBindPort());
 
                         ChannelFuture future = bootstrap.connect().sync();
                         if(future.isSuccess()) {


### PR DESCRIPTION
Allows to bind to a certain network interface for the originating client connection.

To be more precise, you bind to a specific IP and OS routing does its thing. The resolving of the actual IP from a Network Interface is on the client application.

What I'm unsure about is the Getters. If provided with `null` & `0`, JVM will turn it into a `0.0.0.0` but the port will be allocated by the OS. Is there a way to get the assigned port after the connection is established to update the Client object?