### PR TITLE
Optimize SRV resolving only when required

### DIFF
--- a/src/main/java/com/github/steveice10/packetlib/BuiltinFlags.java
+++ b/src/main/java/com/github/steveice10/packetlib/BuiltinFlags.java
@@ -13,6 +13,11 @@ public class BuiltinFlags {
 
     public static final String CLIENT_PROXIED_ADDRESS = "client-proxied-address";
 
+    /**
+     * When set to false, an SRV record resolve is not attempted.
+     */
+    public static final String ATTEMPT_SRV_RESOLVE = "attempt-srv-resolve";
+
     private BuiltinFlags() {
     }
 }


### PR DESCRIPTION
- Add an option to disable SRV resolving
- Don't resolve SRV records if not a domain (in one instance this shortened loading times by five seconds)