### PR TITLE
Fix memory leak by closing De-/Inflater

### DIFF
--- a/src/main/java/com/github/steveice10/packetlib/tcp/TcpPacketCompression.java
+++ b/src/main/java/com/github/steveice10/packetlib/tcp/TcpPacketCompression.java
@@ -26,6 +26,14 @@ public class TcpPacketCompression extends ByteToMessageCodec<ByteBuf> {
     }
 
     @Override
+    public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+        super.handlerRemoved(ctx);
+
+        this.deflater.end();
+        this.inflater.end();
+    }
+
+    @Override
     public void encode(ChannelHandlerContext ctx, ByteBuf in, ByteBuf out) throws Exception {
         int readable = in.readableBytes();
         ByteBufNetOutput output = new ByteBufNetOutput(out);


### PR DESCRIPTION
Java's Inflater and Deflater allocates native resources when instantiated. This pull request closes them when the Compression handler is no longer needed (either when the connection is closed or the handler is removed from the pipeline) to clean up allocated native memory.